### PR TITLE
docs: clarify Sync-Differenzen series handling

### DIFF
--- a/content/de/3VROOMS/Einstellungen/System/SyncDifferenzen/_index.md
+++ b/content/de/3VROOMS/Einstellungen/System/SyncDifferenzen/_index.md
@@ -62,6 +62,8 @@ Geprüft werden insbesondere:
 
 In der Liste werden unter anderem Status, Buchung, Postfach, geänderte Werte, aktuellere Seite, Empfehlung und die letzte Prüfung angezeigt.
 
+Falls Sie eine Differenz auf eine Serie zurückführen müssen, können Sie die Spalten der Liste anpassen und die Spalte **Sync-Element** einblenden. Dort zeigt ROOMS, ob es sich um eine **Einzelbuchung**, eine **Buchungsserie** oder einen **Einzeltermin aus Serie** handelt. Die betroffene Buchung ist direkt verlinkt; bei Serien ist zusätzlich die Serien-ID für gezielte Prüfungen relevant.
+
 ## Status einer Sync-Differenz
 
 {{< bootstrap-table "table table-striped" >}}
@@ -90,7 +92,9 @@ Mögliche Scan-Ziele:
 | **Person/Organisator (Person-ID)** | Prüft synchronisierte Elemente einer bestimmten Person bzw. eines Organisators. |
 {{< /bootstrap-table >}}
 
-Nach dem Start wird der Scan eingereiht oder direkt ausgeführt. Wenn bereits ein Scan läuft, zeigt ROOMS eine entsprechende Meldung an.
+Für **Alle zukünftigen synchronisierten Elemente** wird der Scan im Hintergrund eingereiht. Gezielte Prüfungen für eine Buchung, Serie oder Person werden direkt ausgeführt. Wenn bereits ein Scan läuft, zeigt ROOMS eine entsprechende Meldung an.
+
+Für Support-Analysen kann die Trefferliste zusätzlich über die Manage-API nach Status, Buchungs-ID, Serien-ID, Person-ID oder Typ eingeschränkt werden.
 
 ## Detailansicht
 


### PR DESCRIPTION
## Summary
- Clarifies where Sync-Differenzen expose the Sync-Element / series context.
- Documents that full scans are queued in the background while targeted checks run directly.
- Notes the support/API filtering options for status, booking ID, series ID, person ID, and type.

## Source verification
- Checked ROOMS source: `CalendarSyncDriftController`, `SidePanel.cshtml`, `FindList.ascx`, Manage Sync Drift API endpoints, scan window validation, and German resource strings.
- Confirmed access requires `AdminKonfiguration`, full manual scans are limited to 90 days and queued, targeted scans support booking/series/person IDs, and list/API data includes series context.

## Verification
- `git diff --check`
- `grep -R "ß" -n content/de/3VROOMS/Einstellungen/System/SyncDifferenzen/_index.md` returned no matches
- `/opt/data/tools/hugo-0.108.0/hugo --minify --baseURL '/'`

Note: `npm run test` is not usable in this repo; the script is the placeholder `echo "Error: no test specified" && exit 1`.
