### PR TITLE
docs(ITEM-3697): explain location-filtered Gliederungen

### DIFF
--- a/content/de/3VROOMS-Module/3VROOMS_AddIn_O365Outlook/RessourceBuchen/_index.md
+++ b/content/de/3VROOMS-Module/3VROOMS_AddIn_O365Outlook/RessourceBuchen/_index.md
@@ -20,7 +20,8 @@ Es öffnet sich die Eingabemaske zur Terminerstellung.
    - *Datum und Uhrzeit* werden aus dem Outlook-Ereignis übernommen
    - *Teilnehmerzahl* wird mit den Standardeinstellungen des Benutzenden aus 3V ROOMS ausgefüllt
    - Die Einstellung *Alle Bestuhlungsarten* berücksichtigt auch Räume für mehr Personen als die angegebene Teilnehmerzahl.
-   - *Standort* grenzt die Suche lokal ein, es können mehrere Standort ausgewählt werden.
+   - *Standort* grenzt die Suche lokal ein; es können mehrere Standorte ausgewählt werden.
+   - Welche *Gliederungstypen* (z. B. Raumtyp oder Raumlabel) und *Gliederungen* zur Auswahl stehen, richtet sich nach der gewählten Ressourcenart und den Standorten. Das Add-In zeigt nur Einträge an, die mindestens einer aktiven Ressource an einem gewählten Standort oder dessen Unterstandorten zugeordnet sind. Ändern Sie die Standortauswahl, werden die verfügbaren Gliederungen aktualisiert und nicht mehr passende Auswahlen entfernt. Ist kein Standort gewählt, stehen die standortübergreifend verfügbaren Gliederungen zur Auswahl.
 
       {{< imgproc O365Outlook_web_RaumFilter Resize "960x">}} {{< /imgproc >}}
 

--- a/content/de/3VROOMS/Buchen/FreieRessourcenSuchen/SuchenNachKriterien/_index.md
+++ b/content/de/3VROOMS/Buchen/FreieRessourcenSuchen/SuchenNachKriterien/_index.md
@@ -48,6 +48,8 @@ Sind keine Klassifikationen erfasst, werden keine Klassifikationen eingeblendet.
 
 ### Gliederung
 
+Welche Gliederungstypen und Gliederungen zur Auswahl stehen, richtet sich nach der gewählten Ressourcenart und dem Standort. ROOMS zeigt nur Einträge an, die mindestens einer aktiven Ressource der gewählten Ressourcenart am ausgewählten Standort zugeordnet sind. Ist kein Standort gewählt, stehen die standortübergreifend verfügbaren Gliederungen zur Auswahl. Gibt es für den Standort keine passende Zuordnung, wird der betreffende Gliederungstyp nicht angezeigt.
+
 {{< bootstrap-table "table table-striped" >}}
 | Kriterium            | Funktion                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
 | -------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/content/de/3VROOMS/Kalender/ImKalenderSuchen/_index.md
+++ b/content/de/3VROOMS/Kalender/ImKalenderSuchen/_index.md
@@ -22,8 +22,10 @@ Im Kalenderfilter grenzen Sie ein, welche Ressourcen im Kalender dargestellt wer
 | Suche ohne Substandorte | Aktivieren Sie die Checkbox und lassen Sie sich Standorte ohne Substandorte anzeigen. Begrenzt die Suche auf den  aktuell gewählten Standort oder die aktuelle gewählten Standorte. Die jeweiligen Substandorte werden nicht berücksichtigt. |
 | Ressourcen ID |  Suche über die ID der Ressourcen und über die Bezeichnung in der Benutzer:in  |
 | Kapazität (Anz. Personen) | Wählen Sie die Kapazität für Ihre gesuchte Ressource aus  |
-| Alle Standorte | Die Gliederung fasst bestimmte Attribute einer Ressource wie z.B. Raumtypen: Sitzungszimmer, Schulungsraum, Kundenraum etc. zusammen. Somit erfolgt eine Eingrenzung der Suche. Die Auswahl wird mit Klick auf das _Plus Symbol_ getätigt. Die Inhalte sind kundenspezifisch und können im Bereich der Gliederungen in der Webapplikation durch berechtigte Personen verändert werden. Sind keine Gliederungen erfasst, werden keine Gliederungen eingeblendet. |
+| Gliederungen | Die Gliederung fasst bestimmte Attribute einer Ressource wie z.B. Raumtypen: Sitzungszimmer, Schulungsraum, Kundenraum etc. zusammen. Somit erfolgt eine Eingrenzung der Suche. Die Auswahl wird mit Klick auf das _Plus Symbol_ getätigt. Die Inhalte sind kundenspezifisch und können im Bereich der Gliederungen in der Webapplikation durch berechtigte Personen verändert werden. Sind keine Gliederungen erfasst, werden keine Gliederungen eingeblendet. |
 {{< /bootstrap-table >}}
+
+Welche Gliederungstypen und Gliederungen zur Auswahl stehen, richtet sich nach den gewählten Ressourcenarten und Standorten. Bei mehreren Standorten berücksichtigt ROOMS Einträge, die mindestens einer aktiven Ressource der gewählten Ressourcenarten an einem der Standorte zugeordnet sind. Ist kein Standort gewählt, stehen die standortübergreifend verfügbaren Gliederungen zur Auswahl. Gibt es keine passende Zuordnung, wird der betreffende Gliederungstyp nicht angezeigt.
 
 {{< imgproc Kalender_Sidepanel Resize "960x" >}}
 Sidepanel im Kalender mit Filterfuntionen zur Suche


### PR DESCRIPTION
<!-- hermes-profile: docs-maintainer -->

## Zusammenfassung
- erklärt in der Ressourcensuche, dass verfügbare Gliederungstypen und Gliederungen von Ressourcenart und Standort abhängen
- ergänzt dasselbe Verhalten für einen oder mehrere Standorte im Kalenderfilter
- dokumentiert das standortabhängige Aktualisieren und Bereinigen der Gliederungsauswahl im Outlook Add-In und Wizard
- ersetzt die kundenspezifische Feldbezeichnung «Alle Standorte» in der Kalender-Dokumentation durch den generischen Begriff «Gliederungen»

## Kontext
- Jira: ITEM-3697
- Backend/Web: https://github.com/3volutionsAG/rooms/pull/1106
- Client-Bibliothek: https://github.com/3volutionsAG/ngx-rooms-lib/pull/62
- Add-In/Wizard: https://github.com/3volutionsAG/quickrooms/pull/154
- Die Produktänderungen sind in `develop` enthalten; die Dokumentation beschreibt damit Verhalten für ein kommendes Release.

## Verifikation
- `hugo v0.108.0+extended --minify --baseURL /` (544 Seiten, 741 verarbeitete Bilder)
- Kontrolle der gerenderten Add-In-Seite
- `git diff --check`
- keine `ß` in den geänderten deutschen Markdown-Dateien
