### PR TITLE
docs(ITEM-3094): document Outlook room changes

### DIFF
--- a/content/de/3VROOMS-Module/3VROOMS_AddIn_O365Outlook/BuchungAendern/_index.md
+++ b/content/de/3VROOMS-Module/3VROOMS_AddIn_O365Outlook/BuchungAendern/_index.md
@@ -42,5 +42,15 @@ Die Terminänderung wird automatisch mit 3V ROOMS synchronisiert. Sollte die ROO
 
 Je nach Konfigurationen werden entsprechende Mitteilungen an Teilnehmende, organisierende und verantwortliche Personen versendet.
 
+### Synchronisierten Raum direkt in Outlook wechseln
+
+Wenn die bisherige und die neue Ressource mit Exchange synchronisiert sind, können Sie den Raum direkt im Outlook-Termin wechseln:
+
+1. Fügen Sie den neuen Raum über die Outlook-Raumsuche als Ressource hinzu.
+2. Entfernen Sie den bisherigen Raum aus dem Termin.
+3. Speichern oder senden Sie den Termin.
+
+ROOMS ordnet die Änderung der bestehenden Buchung zu und übernimmt den neuen Raum, sofern die Buchung dort zulässig ist. Lassen Sie nicht mehrere synchronisierte Räume im Termin stehen. Sind vorübergehend nur der bisherige und ein neuer Raum vorhanden, behandelt ROOMS den neuen Raum als Ersatz und bereinigt den bisherigen Raum bei der Synchronisation.
+
 
 Werden Änderungen an Terminen in der Vergangenheit vorgenommen, werden die neuen Information nicht mit 3V ROOMS synchronisiert.

--- a/content/de/Betrieb/Synchronisation/ResourceSync/_index.md
+++ b/content/de/Betrieb/Synchronisation/ResourceSync/_index.md
@@ -102,7 +102,7 @@ Ist die Ressourcen-Sync auf einer Ressource aktiviert, können Vor- und Nachlauf
 {{< bootstrap-table "table table-striped" >}}
 | Einschränkung | Beschreibung |
 |---------------|-------------|
-| **Nur eine Ressource pro Termin** | Bei einem Outlook-Termin darf immer nur eine synchronisierte Ressource hinzugefügt oder eingeladen werden |
+| **Nur eine Ressource pro Termin** | Grundsätzlich darf bei einem Outlook-Termin nur eine synchronisierte Ressource hinzugefügt oder eingeladen sein. Beim oben beschriebenen Raumwechsel dürfen vorübergehend der bisherige und genau ein neuer synchronisierter Raum vorhanden sein. |
 | **Add-in: Ressource nicht manuell einladen** | Wird über das Add-in eine synchronisierte Ressource gebucht, darf sie nicht zusätzlich als Teilnehmer hinzugefügt werden |
 | **Kein direkter Zugriff auf Exchange-Kalender** | Termine sollen nicht direkt auf der Ressourcenmailbox erstellt werden; die Synchronisation ist auf den ROOMS-Flow ausgerichtet |
 {{< /bootstrap-table >}}

--- a/content/de/Betrieb/Synchronisation/ResourceSync/_index.md
+++ b/content/de/Betrieb/Synchronisation/ResourceSync/_index.md
@@ -77,6 +77,22 @@ Wenn in der Exchange-Free/Busy-Anzeige ein erwarteter Ressourcentermin fehlt ode
 - `Microsoft365` synchronisiert Ressourcen über **Graph**
 - Ressourcen laufen bei `Microsoft365` praktisch **app-basiert** - ein Enduser-Consent-Flow wie bei Personen ist dafür nicht vorgesehen
 
+## Raumwechsel in Outlook
+
+Bei einer bereits synchronisierten Buchung kann die organisierende Person den Raum direkt im Outlook-Termin ersetzen:
+
+1. neuen synchronisierten Raum über die Outlook-Raumsuche als Ressource hinzufügen
+2. bisherigen Raum aus dem Termin entfernen
+3. Termin speichern oder senden
+
+ROOMS ordnet den Outlook-Termin der bestehenden Buchung zu und wechselt die ROOMS-Ressource, wenn die Buchung auf dem neuen Raum zulässig ist. Titel, Zeitraum und menschliche Teilnehmende werden aus demselben Outlook-Stand übernommen. Ein Raumwechsel gilt als notifikationsrelevante Änderung; ROOMS versendet die dafür konfigurierten Änderungsmitteilungen.
+
+Sind vorübergehend der bisherige und genau ein neuer synchronisierter Raum im Termin vorhanden, behandelt ROOMS den neuen Raum als Ersatz und bereinigt den bisherigen Raum bei der Synchronisation. Trotzdem soll am Ende nur ein synchronisierter Raum eingeladen sein. Mehrere zusätzliche Räume führen zu einem mehrdeutigen Zustand und sollen vermieden werden.
+
+{{% alert title="Wichtig" color="warning" %}}
+Ein Text im Outlook-Feld **Ort** genügt nicht für einen Raumwechsel. Der neue Raum muss als Exchange-Ressource eingeladen sein.
+{{% /alert %}}
+
 ## Limitationen
 
 {{% alert title="Vor- und Nachlaufzeiten" color="warning" %}}

--- a/content/de/Betrieb/Synchronisation/SyncDetails/_index.md
+++ b/content/de/Betrieb/Synchronisation/SyncDetails/_index.md
@@ -18,7 +18,7 @@ Sie gilt grundsätzlich für:
 | ROOMS Bezeichnung | Exchange / Outlook Bezeichnung | ROOMS → Exchange | Exchange → ROOMS | Spezielle Bemerkungen |
 |---|---|---|---|---|
 | Titel | Subject | x | x | |
-| Ressource / Raum | Location | x |  | |
+| Ressource / Raum | Ressourcenpostfach / Location | x | x | Der Raumwechsel wird über das Ressourcenpostfach erkannt; ein reiner Location-Text löst keinen Raumwechsel aus. |
 | Organisator | Appointment-Ersteller | x | x | bestimmt die Mailbox, in welcher synchronisiert wird; in Exchange nicht änderbar |
 | ExternalReminder | ReminderInMinutes | x | x | |
 | Ist privat | Sensitivity / Privat | x | x | einzelne Serientermine direkt in Outlook anzupassen bleibt eingeschränkt |


### PR DESCRIPTION
<!-- hermes-profile: docs-maintainer -->

## Summary

- document how users replace a synchronised Exchange room directly in Outlook
- explain the resulting ROOMS room change, notification behavior, and transient old/new-room handling for administrators and support
- correct the sync matrix to show that Exchange room changes flow back to ROOMS and that the resource mailbox, not location text alone, identifies the room

## Evidence

- Product change: 3volutionsAG/rooms#1105
- Jira: ITEM-3094
- Related incident: ROMSD-6624
- The product behavior is currently present on `develop` only, so this documents upcoming release behavior.

## Verification

- `git diff --check`
- no `ß` in the changed German Markdown files
- `/opt/data/tools/hugo-0.108.0/hugo --minify --baseURL '/'` (544 pages, 741 processed images)
