### PR TITLE
docs(ROMSD-6644): explain related booking history

### DIFF
--- a/content/de/3VROOMS/Listen/BuchungenSuchen/Anzeigenbereich/DetailansichtBuchungen/Historik/_index.md
+++ b/content/de/3VROOMS/Listen/BuchungenSuchen/Anzeigenbereich/DetailansichtBuchungen/Historik/_index.md
@@ -4,25 +4,38 @@ linkTitle: "Historik"
 weight: 2
 description: 'In der Historik finden Sie die Dokumentation zur Erstellung und sämtlichen Änderungen, die an der Buchung vorgenommen wurden.'
 ---
-## Anzeigenbereich
+## Voraussetzung
 
-  Im Reiter Historik wird Ihnen der Verlauf über Erstellung und Änderungen zur Buchung angezeigt.
+Für den Reiter **Historik** benötigen Sie das globale Recht `Darf historisierte Daten sehen`.
+
+## Wo finde ich die Historik?
+
+1. Öffnen Sie **Listen > Buchungen suchen**.
+2. Öffnen Sie die gewünschte Buchung über den Buchungstitel.
+3. Wechseln Sie in den Reiter **Historik**.
+
+ROOMS zeigt die Erstellung und die Änderungen an der Buchung in zeitlicher Reihenfolge an.
 
 {{< imgproc List_BG_Anzeige_DS_Hist Resize "960x" >}}
-Übersicht Verlauf der Bearbeitung einer Buchung
+Übersicht über den Verlauf der Bearbeitung einer Buchung
 {{< /imgproc >}}
 
+## Details zu einem Eintrag anzeigen
 
-Über das Drop-Down-Dreieck können Sie sich die Details der Erstellung oder der Änderungen anzeigen lassen.
+Über das Drop-down-Dreieck können Sie die Details einer Erstellung oder Änderung aufklappen. Die Tabelle zeigt für jedes geänderte Feld den alten und den neuen Wert.
 
 {{< imgproc List_BG_Anzeige_DS_HistErst_beschriftet Resize "960x" >}}
-Details bezüglich der Erstellung
+Details zur Erstellung
 {{< /imgproc >}}
 
 {{< imgproc List_BG_Anzeige_DS_HistChange_beschriftet Resize "960x" >}}
-Details bezüglich Änderungen an einer Buchung
+Details zu Änderungen an einer Buchung
 {{< /imgproc >}}
+
+Die Details umfassen auch Elemente, die zur Buchung gehören. Wenn beispielsweise mobiles Equipment hinzugefügt oder entfernt wird, erscheint diese Änderung zusammen mit der Buchung im Verlauf. Dies gilt auch, wenn ROOMS das Equipment beim Verschieben der Buchung an einen anderen Standort entfernt.
+
+Bei einem entfernten Eintrag zeigt ROOMS in den aufgeklappten Details einen Eintrag wie **Reservation - Löschen** an. Die ID und, soweit frühere Historikdaten vorhanden sind, die zuletzt bekannten Feldwerte stehen in der Spalte **Alter Wert**. Die Spalte **Neuer Wert** bleibt leer, weil der Eintrag entfernt wurde.
 
 ## Schaltflächen
 
-Informationen zur Funktionsweise der Schaltflächen am unteren Rand des Anzeigenbereichs entnehmen Sie bitte dem Abschnitt [Zusammenfassung](/3vrooms/listen/buchungensuchen/anzeigenbereich/detailansichtbuchungen/zusammenfassung/#schaltflächen).
+Informationen zur Funktionsweise der Schaltflächen am unteren Rand des Anzeigenbereichs finden Sie im Abschnitt [Zusammenfassung](/3vrooms/listen/buchungensuchen/anzeigenbereich/detailansichtbuchungen/zusammenfassung/#schaltflächen).


### PR DESCRIPTION
<!-- hermes-profile: docs-maintainer -->

## Summary
- document the global right required for the **Historik** tab
- explain that related booking changes, including added or removed mobile equipment, appear in the booking history
- clarify how deleted entries and their last-known values are displayed

## Product context
- 3volutionsAG/rooms#1142
- ROMSD-6644
- The product change is merged to `develop`; Jira identifies it for the V4.31/August release, so this documents upcoming behavior.

## Screenshots
No new screenshots. The existing history screenshots remain applicable.

## Verification
- Hugo extended 0.108.0: `hugo --minify --baseURL /`
- `git diff --check`
- changed German Markdown checked for `ß`