### PR TITLE
docs(ITEM-3712): document FlexRule calendar markers

### DIFF
--- a/content/de/3VROOMS/Einstellungen/System/GlobaleParameter/_index.md
+++ b/content/de/3VROOMS/Einstellungen/System/GlobaleParameter/_index.md
@@ -65,6 +65,7 @@ Folgende Daten können Sie ändern:
 | 111 | Bulk print to single document | If set to true bulk printing creates a single merged document. If set to false bulk print creates a zip containing all documents. | true |
 | 86 | Calendar Block Times Color | The color for block times to be used in Calendar Integration calendar. | 88878A |
 | 156 | Calendar DatePicker Year Range | The year range of the calendar datepicker. Example: c-10:c+10 | c-10:c+10 |
+| 164 | FlexRules | Deklarative Regeln für kontextabhängige Resultate wie Kalendermarkierungen. | `{"schemaVersion":"1.0","ruleSets":[]}` |
 | 75 | Cateringblockzeit: Beginn der Blockzeit | Start der Blockzeit für Bestellungen [hh:mm]. | |
 | 74 | Cateringblockzeit: Gruppen ohne Blockzeiten | Semikolonseparierte Liste der Gruppen für welche die Blockzeiten nicht gelten. | |
 | 16 | CleanUpTimeout | Hält die Zeit in Minuten, nach deren Ablauf temporäre Daten ("UnitOfWork"-Kontext, Locking, System-Reservationen) gelöscht werden. | 15 |
@@ -134,3 +135,94 @@ Folgende Daten können Sie ändern:
 | 155 | Wizard Root-Url | The Root-Url of the Addin/Wizard if installed. Please add the url including the "#". Example: https://vnext.wizard.3vrooms.app/#/ | |
 | 54 | Wochentage bei Datumsangaben anzeigen | Einstellung, ob der Wochentag bei Datumsangaben angezeigt werden soll. | false |
 {{< /bootstrap-table >}}
+
+## FlexRules für Kalendermarkierungen konfigurieren
+
+Mit dem globalen Parameter **FlexRules** (ID 164) können Administratoren Buchungen anhand ihres Erstellungsursprungs im Kalender farbig kennzeichnen. Der Standardwert enthält keine Regeln; ohne aktive Regel zeigt ROOMS keine kundenspezifischen Kalendermarkierungen an.
+
+Das folgende Beispiel markiert Buchungen, die über den Jobmanager erstellt wurden:
+
+```json
+{
+  "schemaVersion": "1.0",
+  "ruleSets": [
+    {
+      "id": "calendar-markers",
+      "revision": 1,
+      "rules": [
+        {
+          "id": "jobmanager-calendar-marker",
+          "name": "Jobmanager-Buchungen markieren",
+          "description": "Kennzeichnet Buchungen mit Erstellungsursprung Jobmanager.",
+          "enabled": true,
+          "priority": 100,
+          "context": "booking",
+          "scope": {
+            "resources": {
+              "mode": "all"
+            },
+            "timeFrame": {
+              "mode": "always"
+            }
+          },
+          "conditions": {
+            "any": [
+              {
+                "all": [
+                  {
+                    "expression": "booking.creationOrigin",
+                    "relation": "is-equal-to",
+                    "testValue": {
+                      "type": "creation-origin",
+                      "value": "jobmanager"
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "result": {
+            "type": "calendar-appearance",
+            "markers": [
+              {
+                "key": "jobmanager",
+                "label": "Jobmanager",
+                "icon": "briefcase",
+                "color": "#F59E0B"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}
+```
+
+### Unterstützte Werte
+
+Die erste FlexRules-Version unterstützt folgende Werte:
+
+{{< bootstrap-table "table table-striped" >}}
+| Bereich | Unterstützter Wert | Bedeutung |
+| --- | --- | --- |
+| Schema | `schemaVersion: "1.0"` | Versionsnummer des Konfigurationsformats. |
+| Kontext | `context: "booking"` | Die Regel wird für Buchungen ausgewertet. |
+| Ressourcen | `scope.resources.mode: "all"` | Die Regel gilt für alle Ressourcen. |
+| Zeitraum | `scope.timeFrame.mode: "always"` | Die Regel gilt unabhängig vom Buchungsdatum. |
+| Bedingung | `booking.creationOrigin` / `is-equal-to` | Vergleicht den Erstellungsursprung einer Buchung. |
+| Resultat | `type: "calendar-appearance"` | Fügt der Buchung eine Kalendermarkierung hinzu. |
+| Markierungsfarbe | `#RRGGBB` | Sechsstelliger Hex-Farbwert mit führendem `#`. |
+{{< /bootstrap-table >}}
+
+ROOMS kennt die systemseitigen Erstellungsursprünge `rooms`, `rooms-addin`, `rooms-old-addin`, `rooms-onsite` und `jobmanager`. Der Vergleich ignoriert Gross-/Kleinschreibung sowie Leerzeichen am Anfang und Ende.
+
+Jede Markierung benötigt einen `key`, eine `label`, eine `icon`-Kennung und eine `color`. Innerhalb eines Regelresultats muss der Schlüssel eindeutig sein. Derselbe Schlüssel darf in mehreren Regeln vorkommen, wenn Bezeichnung, Icon-Kennung und Farbe übereinstimmen. Die aktuelle Kalenderansicht stellt die Markierung über Farbe und Bezeichnung dar. Wenn mehrere Regeln passen, zeigt ROOMS die Markierungen aller passenden Regeln an. Regeln mit höherer `priority` werden zuerst ausgewertet; gleiche Markierungsschlüssel werden nur einmal angezeigt.
+
+In `conditions.any` können Sie alternative Bedingungsgruppen definieren. Innerhalb einer Gruppe müssen alle Bedingungen unter `all` erfüllt sein. In der aktuellen Version steht dafür nur der Vergleich des Erstellungsursprungs zur Verfügung.
+
+{{% alert title="Konfiguration vor dem Speichern prüfen" color="warning" %}}
+ROOMS prüft die gesamte JSON-Konfiguration beim Speichern. Ungültiges JSON, unbekannte Felder, nicht unterstützte Werte, fehlende Pflichtfelder oder widersprüchliche Markierungsdefinitionen werden abgewiesen. Dies gilt auch für Regeln mit `enabled: false`.
+
+Sichern Sie den bisherigen Wert vor einer Änderung. Falls eine ungültige Konfiguration ausserhalb der Anwendung gespeichert wird, ignoriert ROOMS sie bei der Auswertung; die betroffenen Markierungen erscheinen dann nicht im Kalender.
+{{% /alert %}}

--- a/content/de/3VROOMS/Kalender/Kalenderansicht/Kalenderbereich/Farbdarstellung/_index.md
+++ b/content/de/3VROOMS/Kalender/Kalenderansicht/Kalenderbereich/Farbdarstellung/_index.md
@@ -13,6 +13,16 @@ Die Farbgebung Ihrer eigenen Buchungen können Sie in Ihren Einstellungen festle
 
 In jeder Kalenderansicht wird Ihnen oben links das Icon _Legende_ angezeigt. Dort sehen Sie mithilfe der Farbgebung, welchen Status eine Buchung hat, z.B. ob sie definitiv oder provisorisch belegt ist. Die Legende enthält auch weitere Kennzeichnungen wie Sperrzeiten, Feiertage, Wochenenden und eigene Reservationen.
 
+### Kundenspezifische Kalendermarkierungen
+
+Wenn in Ihrer ROOMS-Umgebung entsprechende Regeln aktiviert sind, können Buchungen am unteren Rand zusätzlich einen schmalen Farbbalken erhalten. Damit lassen sich beispielsweise Buchungen kennzeichnen, die über den Jobmanager erstellt wurden.
+
+Die Markierung wird anhand des Erstellungsursprungs automatisch gesetzt. Wenn Sie den Mauszeiger auf den Farbbalken bewegen, zeigt ROOMS die konfigurierte Bezeichnung an. Unter **Legende > Markierungen** finden Sie die Farben und Bezeichnungen aller aktiv konfigurierten Markierungen.
+
+{{% alert title="Hinweis" color="info" %}}
+Eine Kalendermarkierung ist nur eine zusätzliche visuelle Kennzeichnung. Sie ersetzt weder Status- oder Klassifikationsfarben noch die Kennzeichnung eigener Reservationen. Sie ändert auch keine Bearbeitungsrechte und sperrt die markierte Buchung nicht.
+{{% /alert %}}
+
 ### Abgrenzung zu anderen Farben
 
 - Die **Ressourcenfarbe** wird auf der Ressource unter [Spezifische Daten](/3vrooms/einstellungen/ressourcen/#spezifische-daten-der-ressource-bearbeiten) gepflegt. Sie kennzeichnet die Ressource, beschreibt aber nicht den Status einer konkreten Buchung.

--- a/content/de/3VROOMS/Kalender/Kalenderansicht/Kalenderbereich/Legende/_index.md
+++ b/content/de/3VROOMS/Kalender/Kalenderansicht/Kalenderbereich/Legende/_index.md
@@ -2,13 +2,18 @@
 title: "Legende"
 linkTitle: "Legende"
 weight: 400
-description: 'Die Ansicht des Kalenders können Sie nach Belieben ändern z.B. in eine Tages-, Wochen- oder Monatsansicht.'
+description: 'Die Legende erklärt die Farben, Symbole und kundenspezifischen Markierungen im Kalender.'
 ---
 
-#### Legende
+## Legende öffnen
 
+Klicken Sie auf das Icon **Legende**. Es öffnet sich ein Popup, das die im Kalender verwendeten und möglichen Farben und Symbole erklärt. Dazu gehören Status, Sperrzeiten, Feiertage, Wochenenden, eigene Reservationen sowie Symbole für Anlässe und Serien.
 
-Klicken Sie auf das Legenden Icon. Es öffnet sich ein Popup, welches alle im Kalender verwendeten/möglichen Farben und Icons auflistet und benennt. z.B. die Farbgebung der Status, Sperrzeiten, Feiertage, Wochenenden und eigenen Reservationen (diese wird aus den persönlichen Einstellungen in den Stammdaten übernommen) sowie die Icons für Anlässe, Serien, usw.
+## Markierungen
+
+Wenn kundenspezifische Kalendermarkierungen aktiviert sind, enthält die Legende zusätzlich den Abschnitt **Markierungen**. Dort sehen Sie die Farbe und Bezeichnung jedes aktiv konfigurierten Markierungstyps. Die Liste kann deshalb auch Markierungen enthalten, die im aktuell sichtbaren Kalenderausschnitt bei keiner Buchung vorkommen.
+
+Weitere Informationen finden Sie unter [Farbdarstellung im Kalender]({{< relref "3VROOMS/Kalender/Kalenderansicht/Kalenderbereich/Farbdarstellung/_index.md" >}}).
 
 {{< imgproc Kalender_Legende_Farben Resize "960x" >}}
 Legende im Kalender zur Farbkennzeichnung der Buchungen


### PR DESCRIPTION
<!-- hermes-profile: docs-maintainer -->

## Summary

- explain the upcoming customer-visible calendar markers and the new **Markierungen** legend section
- document FlexRules system setting 164, its empty default, supported first-version vocabulary, validation behavior, and a Jobmanager example
- clarify that markers supplement existing colors and do not change booking permissions or locking

## Related context

- Product PR: 3volutionsAG/rooms#1146
- Jira: ITEM-3712
- The product behavior is currently on `develop`; it is not yet contained in `main` or `release-candidate`.

## Release gate

- [ ] Do not mark this PR ready or merge it until product PR 3volutionsAG/rooms#1146 is included in `release-candidate` or `main`.

This gate keeps the automatically deployed production documentation aligned with the available ROOMS version.

## Verification

- `hugo --minify --baseURL /` with Hugo Extended 0.108.0: 544 pages built successfully
- `git diff --check`
- parsed the documented JSON example
- checked changed German Markdown files for `ß`
