### PR TITLE
docs(ITEM-3709): Gliederungsfilter erklären

### DIFF
--- a/content/de/3VROOMS/Kalender/ImKalenderSuchen/_index.md
+++ b/content/de/3VROOMS/Kalender/ImKalenderSuchen/_index.md
@@ -27,6 +27,13 @@ Im Kalenderfilter grenzen Sie ein, welche Ressourcen im Kalender dargestellt wer
 
 Welche Gliederungstypen und Gliederungen zur Auswahl stehen, richtet sich nach den gewählten Ressourcenarten und Standorten. Bei mehreren Standorten berücksichtigt ROOMS Einträge, die mindestens einer aktiven Ressource der gewählten Ressourcenarten an einem der Standorte zugeordnet sind. Ist kein Standort gewählt, stehen die standortübergreifend verfügbaren Gliederungen zur Auswahl. Gibt es keine passende Zuordnung, wird der betreffende Gliederungstyp nicht angezeigt.
 
+Wenn Sie mehrere Gliederungen auswählen, bestimmen Sie mit **UND** oder **ODER**, wie ROOMS die Auswahl verknüpft:
+
+- **ODER** (Standard): Der Kalender zeigt Ressourcen an, die mindestens einer ausgewählten Gliederung entsprechen.
+- **UND**: Der Kalender zeigt nur Ressourcen an, die allen ausgewählten Gliederungen entsprechen.
+
+Die Verknüpfung gilt über alle ausgewählten Gliederungstypen hinweg.
+
 {{< imgproc Kalender_Sidepanel Resize "960x" >}}
 Sidepanel im Kalender mit Filterfuntionen zur Suche
 {{< /imgproc >}}

--- a/content/de/3VROOMS/Listen/BuchungenSuchen/ErweiterteSuche/Gliederungen/_index.md
+++ b/content/de/3VROOMS/Listen/BuchungenSuchen/ErweiterteSuche/Gliederungen/_index.md
@@ -6,6 +6,13 @@ description: 'Die können unter anderem Raumtyp oder Equipmenttyp sein.'
 ---
 Die Unterkategorie Gliederung ist, wie die _Ressourcenspezifischen Kriterien_, von der Ressourcenart abhängig und geht auf firmenspezifische Gliederungen ein. Die Ressourcenart wählen Sie in der _Einfachen Suche_ aus.
 
+Wenn Sie mehrere Gliederungen auswählen, bestimmen Sie mit **UND** oder **ODER**, wie ROOMS die Auswahl verknüpft:
+
+- **ODER** (Standard): Die Liste zeigt Buchungen an, deren gebuchte Ressourcen mindestens einer ausgewählten Gliederung entsprechen.
+- **UND**: Die Liste zeigt nur Buchungen an, deren gebuchte Ressourcen gemeinsam allen ausgewählten Gliederungen entsprechen.
+
+Sie können dabei auch Gliederungen verschiedener Ressourcenarten kombinieren, zum Beispiel Raum und Parkplatz.
+
 Beispiel:
 
 


### PR DESCRIPTION
<!-- hermes-profile: docs-maintainer -->

## Zusammenfassung

- Dokumentiert die neue UND-/ODER-Verknüpfung für Gliederungen im Kalenderfilter.
- Erklärt dieselbe Filterlogik in der erweiterten Buchungssuche, einschliesslich Gliederungen verschiedener Ressourcenarten.
- Hält fest, dass ODER die Standardeinstellung ist.

## Hintergrund

Die Produktänderung aus [3volutionsAG/rooms#1110](https://github.com/3volutionsAG/rooms/pull/1110) (`ITEM-3709`) ist in `develop` enthalten und beschreibt damit ein Verhalten der kommenden Version.

## Verifikation

- Hugo Extended 0.108.0: `hugo --minify --baseURL '/'` (545 Seiten erfolgreich erstellt)
- `git diff --check`
- Geänderte deutsche Markdown-Dateien auf `ß` geprüft
